### PR TITLE
Also lists browsers from CurrentUser

### DIFF
--- a/MintPlayer.PlatformBrowser/PlatformBrowser.cs
+++ b/MintPlayer.PlatformBrowser/PlatformBrowser.cs
@@ -28,6 +28,7 @@ namespace MintPlayer.PlatformBrowser
 
             var result = new List<Browser>();
             foreach (var internetKey in new[] { machineInternetKey, userInternetKey }.Where(key => key != null))
+            {
                 foreach (var browserName in internetKey.GetSubKeyNames())
                 {
                     try
@@ -111,7 +112,7 @@ namespace MintPlayer.PlatformBrowser
                         // Disconfigured browser
                     }
                 }
-
+            }
             #endregion
 
             #region Check if Edge is installed


### PR DESCRIPTION
Opera installs itself into `HKEY_CURRENT_USER\SOFTWARE\Clients\...`. Windows 10's Settings > Default Apps seems to respect this registry key, as the browser is shown in the drop down menu for setting the default web browser.